### PR TITLE
Fixed issue #25 in Bin2hex()

### DIFF
--- a/php.go
+++ b/php.go
@@ -1353,7 +1353,18 @@ func Hex2bin(data string) (string, error) {
 func Bin2hex(str string) (string, error) {
 	i, err := strconv.ParseInt(str, 2, 0)
 	if err != nil {
-		return "", err
+		// If input is not binary number
+		// Fix suggested at https://github.com/syyongx/php2go/issues/25 by https://github.com/tobychui
+		if err.(*strconv.NumError).Err == strconv.ErrSyntax {
+			byteArray := []byte(str)
+			var out string
+			for i := 0; i < len(byteArray); i++ {
+				out += strconv.FormatInt(int64(byteArray[i]), 16)
+			}
+			return out, nil
+		} else {
+			return "", err
+		}
 	}
 	return strconv.FormatInt(i, 16), nil
 }

--- a/php_test.go
+++ b/php_test.go
@@ -202,6 +202,9 @@ func TestMath(t *testing.T) {
 	tBin2hex, _ := Bin2hex(tDecbin)
 	equal(t, "64", tBin2hex)
 
+	tBin2hex2, _ := Bin2hex("你好世界")
+	equal(t, "e4bda0e5a5bde4b896e7958c", tBin2hex2)
+
 	tHexdec, _ := Hexdec(tBin2hex)
 	equal(t, int64(100), tHexdec)
 


### PR DESCRIPTION
As suggested in the #25 , the Bin2hex() function has a problem with accepting non-standard data.

I've solved this by first trying the original method, and if it returns a syntax error, it then tries approach suggested by @tobychui.

I've added a second test for the function and both pass successfully.