### PR TITLE
Fixed issue #46 in Strstr()

### DIFF
--- a/php.go
+++ b/php.go
@@ -558,10 +558,14 @@ func Strstr(haystack string, needle string) string {
 		return ""
 	}
 	idx := strings.Index(haystack, needle)
-	if idx == -1 {
+	switch idx {
+	case -1:
 		return ""
+	case 0:
+		return haystack
+	default:
+		return haystack[idx+len([]byte(needle))-1:]
 	}
-	return haystack[idx+len([]byte(needle))-1:]
 }
 
 // Strtr strtr()

--- a/php_test.go
+++ b/php_test.go
@@ -43,6 +43,8 @@ func TestString(t *testing.T) {
 
 	equal(t, "@gmail.com", Strstr("xxx@gmail.com", "@"))
 
+	equal(t, "xxx@gmail.com", Strstr("xxx@gmail.com", "xxx@gmail.com"))
+
 	equal(t, "Hello world", Ucfirst("hello world"))
 
 	equal(t, "hello world", Lcfirst("Hello world"))


### PR DESCRIPTION
Fixed issue #46 in Strstr() when haystack equals needle

This resolves issue #46 where users reported unexpected behavior when using identical strings for haystack and needle.
In addition to the bug fix, this commit also includes new test cases to verify the correct behavior of the Strstr function when the haystack and needle are identical.