### PR TITLE
Fix Soundex table to match the one in soundex.c

### DIFF
--- a/php.go
+++ b/php.go
@@ -14,7 +14,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/text/cases"
 	"hash/crc32"
 	"html"
 	"io"
@@ -34,6 +33,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"golang.org/x/text/cases"
 )
 
 //////////// Date/Time Functions ////////////
@@ -950,21 +951,21 @@ func Soundex(str string) string {
 	}
 	table := [26]rune{
 		// A, B, C, D
-		'0', '1', '2', '3',
+		0, '1', '2', '3',
 		// E, F, G
-		'0', '1', '2',
+		0, '1', '2',
 		// H
-		'0',
+		0,
 		// I, J, K, L, M, N
-		'0', '2', '2', '4', '5', '5',
+		0, '2', '2', '4', '5', '5',
 		// O, P, Q, R, S, T
-		'0', '1', '2', '6', '2', '3',
+		0, '1', '2', '6', '2', '3',
 		// U, V
-		'0', '1',
+		0, '1',
 		// W, X
-		'0', '2',
+		0, '2',
 		// Y, Z
-		'0', '2',
+		0, '2',
 	}
 	last, code, small := -1, 0, 0
 	sd := make([]rune, 4)

--- a/php_test.go
+++ b/php_test.go
@@ -79,6 +79,7 @@ func TestString(t *testing.T) {
 	equal(t, float64(50), percent)
 
 	equal(t, "H416", Soundex("Heilbronn"))
+	equal(t, "M520", Soundex("Mansa"))
 
 	equal(t, 14, len(Uniqid("x")))
 	equal(t, true, bytes.HasPrefix([]byte(Uniqid("x")), []byte("x")))


### PR DESCRIPTION
Soundex table in [soundex.c](https://github.com/php/php-src/blob/4d46f2632781cda34d303199b987319200a5ec1a/ext/standard/soundex.c#L29-L55) uses integer 0 (for A, E, H, I, O, U, W and Y) but php2go version uses character '0' which is not correct and soundex didn't work as in original implementation.