### PR TITLE
fix: fix slice init length

### DIFF
--- a/php.go
+++ b/php.go
@@ -579,7 +579,7 @@ func Strtr(haystack string, params ...interface{}) string {
 		if length == 0 {
 			return haystack
 		}
-		oldnew := make([]string, length*2)
+		oldnew := make([]string, 0, length*2)
 		for o, n := range pairs {
 			if o == "" {
 				return haystack


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW